### PR TITLE
First-run flow: stop handing the user the gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,15 @@ The gateway runs as a local daemon, and the **whole process runs inside the OS s
 | `uv tool` | `uv tool install flowly-ai` | Packaged PyPI install; tracks releases |
 | Source | `git clone … && pip install -e ".[dev]"` | Contributors |
 
-After install, run `flowly setup`. To run without a terminal session open:
+After install, run `flowly setup` to pick a provider, then `flowly` to chat — it
+starts the gateway for you if none is running.
+
+To keep it up without anyone running `flowly` (channels reachable, cron jobs
+firing, across reboots):
 
 ```bash
 flowly service install --start    # launchd (macOS) / systemd (Linux) / Task Scheduler (Windows)
 ```
-
-It survives reboots and terminal close.
 
 ---
 

--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -71,7 +71,7 @@ flowly --version
 
 ## Running as a background service
 
-By default Flowly runs in your terminal session. To keep the gateway running without a terminal — surviving reboots and terminal close — install it as a background service:
+Bare `flowly` starts the gateway on demand, so nothing below is required to chat. Install it as a background service when you want the gateway up **without anyone running `flowly`** — keeping channels reachable and scheduled jobs firing, across logout and reboots:
 
 ```bash
 flowly service install --start

--- a/content/docs/getting-started/quickstart.md
+++ b/content/docs/getting-started/quickstart.md
@@ -37,7 +37,9 @@ See [Setup wizard](./setup-wizard.md) for all subcommands.
 flowly
 ```
 
-Bare `flowly` opens the terminal chat. Type a message and the agent responds. Inside the chat you can switch provider and model on the fly:
+Bare `flowly` opens the terminal chat. Type a message and the agent responds. If the gateway (the background process that actually runs your agent) isn't up, `flowly` starts it for you — there is no separate "start the server" step.
+
+Inside the chat you can switch provider and model on the fly:
 
 ```bash
 /provider openrouter
@@ -56,7 +58,7 @@ flowly agent -m "Summarize the README in this directory"
 
 ## Where to next
 
-- Run Flowly in the background so it stays reachable: [Service](../using-flowly/service.md) — `flowly service install --start`
+- Keep Flowly running across logins and reboots: [Service](../using-flowly/service.md) — `flowly service install --start` (optional; `flowly` already starts the gateway on demand)
 - Add a Telegram, Discord, or Slack bot: [Channels overview](../channels/overview.md)
 - Tune models, tools, and behavior: [Configuration](../using-flowly/configuration.md)
 - Control shell execution and approvals: [Sandbox and approvals](../using-flowly/sandbox-and-approvals.md)

--- a/content/docs/reference/environment-variables.md
+++ b/content/docs/reference/environment-variables.md
@@ -87,6 +87,7 @@ These let tools pick up credentials from the environment instead of `config.json
 | Variable | Default | What it does |
 |---|---|---|
 | `FLOWLY_TUI_THEME` | `flowly` | Default TUI theme. |
+| `FLOWLY_NO_GATEWAY_AUTOSTART` | — | Set to `1` to stop bare `flowly` from starting the gateway when none is running. Without it, `flowly` starts an installed service, or installs and starts one, before opening the chat. Never fires for a non-loopback `--host`, for a `--port` other than the configured one, or outside an interactive terminal. |
 | `FLOWLY_BROWSER_PLAN_ENABLED` | `1` | Toggles the `browser_plan` tool. |
 | `FLOWLY_BROWSER_PLAN_PERSIST` | — | Controls browser-plan persistence. |
 

--- a/content/docs/using-flowly/service.md
+++ b/content/docs/using-flowly/service.md
@@ -4,6 +4,12 @@ eyebrow: Using Flowly
 description: The Flowly gateway can run as a background service so it stays up without a terminal session — surviving reboots and terminal close — keeping your channels reachable.
 ---
 
+> [!NOTE]
+> You don't need this to use Flowly. Bare `flowly` starts the gateway itself
+> when none is running. Install the service when you want it up **without
+> anyone typing `flowly`** — across logins and reboots, so channels stay
+> reachable and scheduled jobs keep firing.
+
 ## Install and lifecycle
 
 ```bash
@@ -80,7 +86,7 @@ sudo loginctl enable-linger "$USER"              # or: flowly doctor --fix
 
 Genuine crashes are covered by `Restart=always` + `StartLimitIntervalSec=0` (retried indefinitely, never permanently `failed`).
 
-**Restart reports ok, but the port never comes back.** The unit was probably installed by a *previous* Flowly install and points at a binary that no longer exists — `restart`/`start` detect this and print the fix: `flowly service install --start` rewrites the unit onto the current install. (The install script also does this automatically when it finds an existing unit.)
+**Restart reports ok, but the port never comes back.** The unit was probably installed by a *previous* Flowly install and points at a binary that no longer exists — `restart`/`start` detect this and print the fix: `flowly service install --start` rewrites the unit onto the current install. The install script does this for you when the unit dangles or belongs to the install it is replacing; a unit pointing at a *different, working* install is left alone, so re-running the installer against a throwaway checkout can't repoint your real service at a directory that is about to be deleted.
 
 **Windows — it runs, then is down a few hours later.** This is exactly what the console-less supervisor fixes: the launcher relaunches the gateway whenever it exits, so a mid-life crash recovers on its own within seconds. If it still won't stay up:
 

--- a/content/docs/using-flowly/troubleshooting.md
+++ b/content/docs/using-flowly/troubleshooting.md
@@ -71,9 +71,21 @@ the port. One command rewrites the unit onto the current install and starts it:
 flowly service install --start
 ```
 
-Current releases close this loophole from both ends: the install script
-refreshes an existing service unit automatically, and `service restart`/`start`
-detect the stale executable and print exactly this fix instead of a false ✓.
+Current releases close this loophole from both ends: the install script adopts
+a unit that dangles or belongs to the install it is replacing (one pointing at
+a *different, working* install is deliberately left alone), and `service
+restart`/`start` detect the stale executable and print exactly this fix instead
+of a false ✓.
+
+**"Gateway not reachable" when I run `flowly`.**
+`flowly` starts the gateway itself when none is running, so seeing this means
+the start was refused or failed — and the line underneath says which. Common
+reasons: you passed a `--host` that names another machine (nothing here to
+start — check that machine and the firewall), you passed a one-off `--port`
+that isn't the configured one, you're not on an interactive terminal, or
+`FLOWLY_NO_GATEWAY_AUTOSTART=1` is set. If the service manager itself refused,
+the last line of its error is shown; `flowly service logs --no-follow` has the
+rest.
 
 **Port already in use / "gateway already running".**
 Something is already listening on the gateway port (default `18790`) — usually a

--- a/flowly/cli/commands.py
+++ b/flowly/cli/commands.py
@@ -71,18 +71,13 @@ def main(
         return
 
     # Smart entry: provider configured → open TUI, else first-run setup.
-    # Failure to read config (corrupt JSON, fresh install) shouldn't
-    # crash here — fall through to the unconfigured prompt instead of
-    # exploding before the user even sees a message.
-    try:
-        from flowly.config.loader import load_config
-        from flowly.integrations.active_provider import resolve_active_provider
-        cfg = load_config()
-        active = resolve_active_provider(cfg)
-    except Exception:
-        active = None
+    # ``provider_readiness`` is the one shared answer (see
+    # ``flowly/integrations/active_provider.py``) and never raises, so a
+    # corrupt config or a fresh install lands on the setup prompt rather
+    # than a traceback before the user has seen anything.
+    from flowly.integrations.active_provider import provider_readiness
 
-    if active is None:
+    if not provider_readiness().ready:
         from flowly.cli.onboard_cmd import run_onboarding
 
         run_onboarding()

--- a/flowly/cli/login_cmd.py
+++ b/flowly/cli/login_cmd.py
@@ -50,6 +50,7 @@ from flowly.account.health import (
     check_provider_corruption,
     check_relay_state,
 )
+from flowly.integrations.active_provider import provider_readiness
 
 console = Console()
 
@@ -245,6 +246,43 @@ def _mint_and_save_account_key(account) -> bool:
     return ensure_account_key(account)
 
 
+def _repair_account_credentials(account) -> bool:
+    """Re-issue the account key during ``--repair``.
+
+    ``--repair`` re-registers the machine and rewrites relay config, which
+    are the two things that were *not* broken for a user whose mint failed.
+    The key is the credential the LLM proxy actually authenticates, so a
+    repair that skips it leaves the install exactly as unusable as it found
+    it. Idempotent: an existing key is kept, not replaced.
+    """
+    return _mint_and_save_account_key(account)
+
+
+def _print_provider_verdict() -> bool:
+    """Close the sign-in with what is true, not with what we hoped for.
+
+    Sign-in and provisioning are separate steps against separate endpoints;
+    the first can succeed while the second doesn't. Returns whether Flowly
+    can serve a request now, so callers can pick an exit code.
+    """
+    if provider_readiness().ready:
+        console.print()
+        console.print("  Ready. Run [cyan]flowly[/] to start chatting.\n")
+        return True
+
+    console.print(
+        "\n  [yellow]⚠ Signed in, but the account key hasn't reached this "
+        "machine.[/]\n"
+        "  [dim]Sign-in and key issuing are separate steps — the second one "
+        "didn't land, so there is nothing to bill LLM calls to yet.[/]\n"
+        "  Retry:  [cyan]flowly login[/]            "
+        "[dim]— reissues the key, no browser needed[/]\n"
+        "  Or:     [cyan]flowly setup[/]            "
+        "[dim]— use your own API key instead[/]\n"
+    )
+    return False
+
+
 def login(
     no_browser: bool = typer.Option(
         False, "--no-browser",
@@ -376,12 +414,15 @@ def login(
             console.print()
             console.print("  [dim](dry run — nothing changed)[/]\n")
         else:
+            # The account key is the credential the LLM proxy authenticates.
+            # Repairing server registration and relay config without it fixes
+            # everything except the thing most likely to be broken.
+            _repair_account_credentials(account)
             _print_repair_summary(
                 result,
                 header=f"Account: {account.email or account.user_id}",
             )
-            console.print()
-            console.print("  Ready. Run [cyan]flowly[/] to start chatting.\n")
+            _print_provider_verdict()
         return
 
     # ── Path: already signed in — detect gaps, never mutate ──────
@@ -539,8 +580,9 @@ def login(
         raise typer.Exit(code=1)
 
     # Provider: ALWAYS auto-provision an account key so the user is billed
-    # immediately without ever dealing with keys (Source 0). Best-effort.
-    _mint_and_save_account_key(account)
+    # immediately without ever dealing with keys (Source 0). Best-effort —
+    # the verdict printed at the end reports whether it actually landed.
+    minted = _mint_and_save_account_key(account)
 
     # Reach: remote / phone access via the relay is OPT-IN — it registers a
     # server. Ask interactively unless the caller forced it with
@@ -578,15 +620,24 @@ def login(
             result,
             header=f"Signed in as {account.email or account.user_id}",
         )
-    else:
+    elif minted:
         console.print(
             f"  [green]✓[/] Signed in as [b]{account.email or account.user_id}[/] — "
             "Flowly provider ready, billed to your account (no relay)."
+        )
+    else:
+        console.print(
+            f"  [green]✓[/] Signed in as [b]{account.email or account.user_id}[/]."
         )
 
     console.print(
         f"  [green]✓[/] Tokens saved to {credential_storage_status()}"
     )
-    console.print()
-    console.print("  Ready. Run [cyan]flowly[/] to start chatting.\n")
-    audit_log.info("cli.login.full_flow_success", relay=bool(want_relay))
+    # Exit code stays 0 even when the key didn't land: the sign-in itself
+    # succeeded and the tokens are stored, so failing here would tell every
+    # caller (installers, Desktop, scripts) that login broke when it didn't.
+    # The verdict above is what tells the user what's left to do.
+    ready = _print_provider_verdict()
+    audit_log.info(
+        "cli.login.full_flow_success", relay=bool(want_relay), provider_ready=ready
+    )

--- a/flowly/cli/onboard_cmd.py
+++ b/flowly/cli/onboard_cmd.py
@@ -166,23 +166,36 @@ def seed_workspace() -> Path:
 
 
 def _already_configured() -> bool:
-    """True when a provider is set up OR a Flowly account is signed in."""
-    try:
-        from flowly.config.loader import load_config
-        from flowly.integrations.active_provider import resolve_active_provider
+    """True when Flowly can actually serve a request right now.
 
-        if resolve_active_provider(load_config()) is not None:
-            return True
-    except Exception:
-        pass
-    try:
-        from flowly.account.health import check_token_state
+    This used to also return True for "a Flowly account is signed in", which
+    is not the same thing: ``ensure_account_key`` is best-effort, so a
+    sign-in whose mint failed leaves an account with nothing to bill
+    against. Onboarding then declared victory while ``service install
+    --start`` refused to run the gateway — and bare ``flowly``, finding no
+    provider, reopened onboarding. One definition now, shared with the
+    service manager (see :func:`provider_readiness`).
+    """
+    from flowly.integrations.active_provider import provider_readiness
 
-        if check_token_state().has_account:
-            return True
-    except Exception:
-        pass
-    return False
+    return provider_readiness().ready
+
+
+def _warn_signed_in_but_unusable() -> None:
+    """Explain the one state that looks configured but cannot serve a request."""
+    from flowly.integrations.active_provider import provider_readiness
+
+    state = provider_readiness()
+    if state.ready or not state.has_account:
+        return
+    console.print(
+        "\n  [yellow]![/yellow] You're signed in, but no usable credential "
+        "reached this machine yet\n"
+        "    [dim](the account key couldn't be issued — usually a network or "
+        "backend hiccup).[/dim]\n"
+        "    Retry with [cyan]flowly login[/cyan], or pick your own API key "
+        "below."
+    )
 
 
 @contextlib.contextmanager
@@ -429,13 +442,28 @@ def _model_label(m) -> str:
 
 
 def _offer_start_gateway() -> None:
-    """Ask whether to start the gateway in the background, then guide next steps."""
+    """Offer to keep Flowly running in the background, then guide next steps.
+
+    Declining is now cheap: ``flowly`` starts the gateway on demand, so the
+    question is really "keep it running across logins?" rather than "may I
+    make the product work?". Only the failure path still spells out the
+    manual command, because that is the one case where the user has to do
+    something themselves.
+    """
     from rich.prompt import Confirm
 
     try:
-        start_now = Confirm.ask("\n  Start Flowly in the background now?", default=True)
+        start_now = Confirm.ask("\n  Keep Flowly running in the background?", default=True)
     except (EOFError, KeyboardInterrupt):
         start_now = False
+
+    if not start_now:
+        console.print(
+            "\n  Next:\n"
+            "    [cyan]flowly[/cyan]   [dim]— start chatting "
+            "(it starts the gateway for you)[/dim]"
+        )
+        return
 
     if start_now:
         # Resolve the launcher properly instead of trusting sys.argv[0]: under
@@ -515,6 +543,9 @@ def _run_provider_step() -> bool:
     if _already_configured():
         _prompt_model(choice)
         return True
+    # Sign-in can succeed while the credential behind it doesn't arrive. Say
+    # so here rather than dropping the user back on the picker in silence.
+    _warn_signed_in_but_unusable()
     return False
 
 

--- a/flowly/cli/service_cmd.py
+++ b/flowly/cli/service_cmd.py
@@ -558,7 +558,7 @@ def _start_launchd_service(
     *,
     domain: str | None = None,
 ) -> str:
-    """Start a launch agent, with Hermes-style EIO recovery and fallback."""
+    """Start a launch agent, recovering from launchctl EIO with a detached fallback."""
     resolved_domain = domain or _launchd_domain(label)
     target = _launchd_target(label, resolved_domain)
 
@@ -720,16 +720,34 @@ def _provider_configured() -> bool:
     crash-restart loop. We preflight the same check so service commands
     can refuse to *start* an unconfigured gateway — the unit still gets
     installed so it's ready the moment ``flowly setup`` is done.
+
+    Shares :func:`provider_readiness` with onboarding so the screen that
+    says "you're set up" and this preflight can never disagree.
     """
-    try:
-        from flowly.config.loader import load_config
-        from flowly.integrations.active_provider import resolve_active_provider
-        return resolve_active_provider(load_config()) is not None
-    except Exception:
-        return False
+    from flowly.integrations.active_provider import provider_readiness
+
+    return provider_readiness().ready
 
 
 def _warn_no_provider(action: str) -> None:
+    from flowly.integrations.active_provider import provider_readiness
+
+    if provider_readiness().has_account:
+        # Signed in, but no credential landed — sending this user to
+        # `flowly setup` to "pick a provider" reads as though the sign-in
+        # they just completed didn't count. Point at the actual repair.
+        console.print(
+            f"[yellow]Signed in, but no usable credential yet — not {action}.[/yellow]\n"
+            "The account key hasn't reached this machine, so the gateway has "
+            "nothing to call. Retry it, then start the service:"
+        )
+        console.print(
+            "  [cyan]flowly login[/]            [dim]— reissue the account key[/]"
+        )
+        console.print(
+            "  [cyan]flowly service start[/]    [dim]— start once it lands[/]"
+        )
+        return
     console.print(
         f"[yellow]No LLM provider configured — not {action}.[/yellow]\n"
         "The gateway would crash-loop without one. Configure a provider, "

--- a/flowly/cli/setup.py
+++ b/flowly/cli/setup.py
@@ -1651,6 +1651,8 @@ def setup_all() -> None:
     # Done
     console.print(f"\n{'─' * 40}")
     console.print("[bold green]✓ Setup complete![/bold green]\n")
-    console.print("Start Flowly with: [cyan]flowly gateway[/cyan]")
-    console.print("Background mode: [cyan]flowly service install --start[/cyan]")
+    console.print("Start chatting with: [cyan]flowly[/cyan]")
+    console.print(
+        "[dim]Keep it running across logins: [/dim][cyan]flowly service install --start[/cyan]"
+    )
     console.print()

--- a/flowly/cli/setup_cmd.py
+++ b/flowly/cli/setup_cmd.py
@@ -105,17 +105,21 @@ def _print_runtime_next_steps() -> None:
 
     console.print(f"[green]✓[/] Provider ready: [b]{active.source}[/]")
     console.print()
-    console.print("Now start the gateway, then chat:")
+    console.print("You're set:")
+    console.print(
+        "  [cyan]flowly[/]                          "
+        "[dim]— start chatting (starts the gateway if it isn't running)[/]"
+    )
+    console.print()
+    console.print("[dim]Optional:[/]")
     console.print(
         "  [cyan]flowly service install --start[/]  "
-        "[dim](Recommended — runs the gateway in the background)[/]"
+        "[dim](keep the gateway running in the background, across logins)[/]"
     )
     console.print(
         "  [cyan]flowly gateway[/]                  "
         "[dim](foreground — keeps this terminal busy; use a 2nd one to chat)[/]"
     )
-    console.print()
-    console.print("  Then: [cyan]flowly[/]  [dim]— open the chat UI[/]")
 
 
 @setup_app.command("byok")

--- a/flowly/cli/setup_summary.py
+++ b/flowly/cli/setup_summary.py
@@ -304,9 +304,14 @@ def _next_commands(summary: SetupSummary) -> list[tuple[str, str]]:
     if not summary.provider_ready:
         cmds.append(("flowly setup", "choose an account or API key"))
         return cmds
-    if not summary.gateway_installed:
-        cmds.append(("flowly service install --start", "run the gateway in the background"))
+    # `flowly` leads. It starts the gateway itself when one isn't running, so
+    # the service command below is a convenience (keep it running at login),
+    # not a prerequisite the user has to clear before chatting.
     cmds.append(("flowly", "start chatting"))
+    if not summary.gateway_installed:
+        cmds.append(
+            ("flowly service install --start", "optional — keep it running at login")
+        )
     cmds.append(("flowly memory import-prompt", "bring memories from ChatGPT/Gemini"))
     if not summary.configured_tools:
         cmds.append(("flowly setup tools", "add integrations"))

--- a/flowly/cli/update_cmd.py
+++ b/flowly/cli/update_cmd.py
@@ -176,7 +176,7 @@ def _windows_self_update(cmd: list[str]) -> int:
         pip_line,
         "if errorlevel 1 ( echo. & echo Update FAILED. & echo. & pause & exit /b 1 )",
         "echo.",
-        "echo Flowly updated. To continue:  flowly service install --start  then  flowly",
+        "echo Flowly updated. To continue:  flowly",
         "echo You can close this window.",
         "pause >nul",
     ]

--- a/flowly/diagnostics/checks.py
+++ b/flowly/diagnostics/checks.py
@@ -18,6 +18,7 @@ from urllib.parse import quote
 
 from flowly.diagnostics.config import find_unknown_keys, read_config_snapshot
 from flowly.diagnostics.models import DoctorCheck, DoctorContext, RepairRisk
+from flowly.profile import default_home
 
 _WORKSPACE_FILES = ("AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md", "HEARTBEAT.md")
 _FLOWLY_BEARER_RE = re.compile(r"^[A-Za-z0-9_-]{12,32}:[0-9a-f]{32,128}$")
@@ -704,6 +705,32 @@ def check_service_definition(ctx: DoctorContext) -> None:
     except (OSError, ValueError, ET.ParseError, plistlib.InvalidFileException) as exc:
         ctx.error("service", f"Service definition cannot be parsed ({type(exc).__name__})")
         return
+
+    # Whose unit is this? The service label is a single global name, so every
+    # home sees whichever home installed it last at the well-known path. Settle
+    # ownership BEFORE validating the command: judging a foreign unit's
+    # executable reports someone else's broken install as this profile's error.
+    if service_home:
+        owner = Path(service_home).expanduser().resolve()
+        if owner != ctx.data_dir.resolve():
+            detail = f"Service: {service_home}\nThis profile: {ctx.data_dir}"
+            if ctx.data_dir.resolve() == default_home().resolve():
+                # The default home owns the label. A unit pointing elsewhere
+                # means this install's service was taken over — its gateway
+                # is not the one running.
+                ctx.error(
+                    "service",
+                    "Service FLOWLY_HOME does not match the active profile",
+                    detail,
+                )
+            else:
+                ctx.warn(
+                    "service",
+                    "Background service belongs to another Flowly home",
+                    detail,
+                )
+            return
+
     if not argv:
         ctx.error("service", "Service definition has no executable command")
         return
@@ -713,13 +740,6 @@ def check_service_definition(ctx: DoctorContext) -> None:
         return
     if "gateway" not in argv:
         ctx.warn("service", "Service command does not visibly invoke the Flowly gateway")
-        return
-    if service_home and Path(service_home).expanduser().resolve() != ctx.data_dir.resolve():
-        ctx.error(
-            "service",
-            "Service FLOWLY_HOME does not match the active profile",
-            f"Service: {service_home}\nDoctor: {ctx.data_dir}",
-        )
         return
     ctx.ok("service", f"Service definition is structurally valid: {path}")
 

--- a/flowly/integrations/active_provider.py
+++ b/flowly/integrations/active_provider.py
@@ -66,6 +66,58 @@ class ActiveProvider:
     account_id: str = ""
 
 
+@dataclass(frozen=True)
+class ProviderReadiness:
+    """Can Flowly serve a request right now — and if not, why not?
+
+    ``ready`` is the ONLY question the product should ask when deciding
+    whether setup is finished, whether the gateway may start, and whether
+    bare ``flowly`` opens the chat UI. It used to be asked in two
+    incompatible ways: onboarding accepted "a Flowly account is signed in"
+    while the service manager demanded a resolvable provider. A sign-in
+    whose account-key mint quietly failed satisfies the first and not the
+    second, which told the user they were done and then refused to start.
+
+    ``has_account`` exists so that in-between state stays *nameable*: the
+    user really is signed in, there is just nothing to bill against yet, and
+    saying so beats sending them back through the picker with no explanation.
+    """
+
+    ready: bool
+    provider: ActiveProvider | None
+    has_account: bool
+
+
+def provider_readiness(config: Config | None = None) -> ProviderReadiness:
+    """Resolve the provider once and report it as a readiness verdict.
+
+    Never raises: a fresh machine has no config file, and every caller here
+    sits on a first-run path where an exception would be worse than a
+    "nothing configured yet" answer.
+    """
+    provider: ActiveProvider | None = None
+    try:
+        if config is None:
+            from flowly.config.loader import load_config
+
+            config = load_config()
+        provider = resolve_active_provider(config)
+    except Exception as exc:  # noqa: BLE001 — first-run paths must not crash
+        logger.debug("provider readiness could not resolve a provider: %s", exc)
+
+    has_account = False
+    try:
+        from flowly.account.health import check_token_state
+
+        has_account = check_token_state().has_account
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("provider readiness could not read the account: %s", exc)
+
+    return ProviderReadiness(
+        ready=provider is not None, provider=provider, has_account=has_account
+    )
+
+
 def resolve_active_provider(config: Config) -> ActiveProvider | None:
     """Return the provider that will serve the next LLM request.
 

--- a/flowly/integrations/gateway_autostart.py
+++ b/flowly/integrations/gateway_autostart.py
@@ -1,0 +1,187 @@
+"""Start the local gateway on demand, so ``flowly`` is the only command.
+
+The gateway is a separate process from the chat UI, and until now that
+implementation detail was the user's problem: a configured install that
+happened to have no running gateway printed
+
+    Gateway not reachable on 127.0.0.1:18790.
+    Start the gateway, then run flowly again:
+      flowly service install --start
+      flowly gateway
+
+— a product telling someone to run the command it could have run itself.
+This module runs it.
+
+What it will and won't do
+-------------------------
+It only ever touches the *local* gateway for the *configured* port, and
+only from a real terminal:
+
+* a non-loopback host means the gateway lives on another machine — there is
+  nothing here to start;
+* a port that isn't the configured one came from a one-off ``--port`` flag,
+  so we may start an already-installed unit but never bake that port into a
+  new one;
+* a non-TTY caller is Flowly Desktop (it spawns this binary as a subprocess
+  and owns the gateway lifecycle itself) or a script — both must be left
+  alone;
+* ``FLOWLY_NO_GATEWAY_AUTOSTART=1`` opts out entirely.
+
+Failure is always a report, never an exception: the caller falls back to
+telling the user how to do it by hand.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+DEFAULT_TIMEOUT = 25.0
+_POLL_INTERVAL = 0.4
+_OPT_OUT_ENV = "FLOWLY_NO_GATEWAY_AUTOSTART"
+
+
+@dataclass(frozen=True)
+class AutostartResult:
+    """What happened when we tried to make the gateway reachable.
+
+    ``running`` is the only thing a caller must branch on. ``attempted``
+    separates "we tried and it didn't work" from "this wasn't ours to
+    start", which changes what the user should be told. ``installed_unit``
+    says whether a persistent background service was created, because that
+    is a change to their machine and deserves a line of output.
+    """
+
+    running: bool
+    attempted: bool = False
+    installed_unit: bool = False
+    detail: str = ""
+
+
+def _port_open(host: str, port: int, timeout: float = 0.5) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _is_loopback(host: str) -> bool:
+    from flowly.gateway.auth import is_loopback_host
+
+    return is_loopback_host(host)
+
+
+def _configured_port() -> int:
+    """The port the installed service would use — 18790 unless configured."""
+    try:
+        from flowly.config.loader import load_config
+
+        return int(load_config().gateway.port)
+    except Exception:
+        return 18790
+
+
+def _unit_installed() -> bool:
+    """True when a launchd/systemd/Windows unit for the gateway exists."""
+    try:
+        from flowly.cli.service_cmd import DEFAULT_SERVICE_LABEL, _service_paths
+
+        return any(p is not None and p.exists() for p in _service_paths(DEFAULT_SERVICE_LABEL))
+    except Exception:
+        return False
+
+
+def _flowly_argv() -> list[str]:
+    from flowly.cli.service_cmd import _resolve_flowly_exec_argv
+
+    return _resolve_flowly_exec_argv()
+
+
+def _autostart_allowed(host: str, port: int) -> tuple[bool, str]:
+    if os.environ.get(_OPT_OUT_ENV, "").strip() == "1":
+        return False, f"{_OPT_OUT_ENV}=1"
+    if not _is_loopback(host):
+        return False, f"{host} is not this machine"
+    try:
+        interactive = sys.stdin.isatty()
+    except Exception:
+        interactive = False
+    if not interactive:
+        # Desktop / scripts: never spawn a service behind their back.
+        return False, "not an interactive terminal"
+    return True, ""
+
+
+def ensure_gateway_running(
+    host: str,
+    port: int,
+    *,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> AutostartResult:
+    """Make the local gateway reachable, starting it if that's ours to do."""
+    if _port_open(host, port):
+        return AutostartResult(running=True)
+
+    allowed, why = _autostart_allowed(host, port)
+    if not allowed:
+        return AutostartResult(running=False, detail=why)
+
+    install_unit = not _unit_installed()
+    if install_unit and port != _configured_port():
+        # A one-off --port. Starting the installed unit would bind the
+        # configured port instead, and installing one would persist a port
+        # the user never asked to keep.
+        return AutostartResult(
+            running=False, detail=f"port {port} is not the configured gateway port"
+        )
+
+    argv = list(_flowly_argv())
+    argv += ["service", "install", "--start"] if install_unit else ["service", "start"]
+
+    try:
+        completed = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 — a failed start must not kill the CLI
+        return AutostartResult(running=False, attempted=True, detail=str(exc))
+
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()
+        return AutostartResult(
+            running=False,
+            attempted=True,
+            installed_unit=False,
+            detail=_last_line(detail) or f"exit {completed.returncode}",
+        )
+
+    # `service install --start` already waits for the gateway's health
+    # endpoint, but `service start` may return before the socket is up, and
+    # either way the port is what the TUI is about to dial.
+    if not _wait_for_port(host, port, timeout=timeout):
+        return AutostartResult(
+            running=False,
+            attempted=True,
+            installed_unit=install_unit,
+            detail=f"the service started but nothing is listening on {host}:{port}",
+        )
+
+    return AutostartResult(running=True, attempted=True, installed_unit=install_unit)
+
+
+def _wait_for_port(host: str, port: int, *, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        if _port_open(host, port):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_POLL_INTERVAL)
+
+
+def _last_line(text: str) -> str:
+    """The last non-empty line — service managers bury the reason at the end."""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return lines[-1] if lines else ""

--- a/flowly/integrations/gateway_autostart.py
+++ b/flowly/integrations/gateway_autostart.py
@@ -44,6 +44,25 @@ DEFAULT_TIMEOUT = 25.0
 _POLL_INTERVAL = 0.4
 _OPT_OUT_ENV = "FLOWLY_NO_GATEWAY_AUTOSTART"
 
+# Headroom over the child's OWN start budget. `service install --start` already
+# waits for the gateway's health endpoint before returning, so killing it on
+# our timer would abort a legitimate start mid-`launchctl bootstrap` and report
+# a failure that never happened. Interpreter startup and the service-manager
+# round trip are on top of that budget, and both are slower on a cold Windows
+# box than anywhere else — hence a generous margin rather than a tight one.
+_COMMAND_HEADROOM = 30.0
+
+
+def _command_timeout() -> float:
+    """How long to let ``flowly service …`` run before giving up on it."""
+    try:
+        from flowly.cli.service_cmd import SERVICE_START_TOTAL_BUDGET
+
+        budget = float(SERVICE_START_TOTAL_BUDGET)
+    except Exception:
+        budget = 25.0
+    return budget + _COMMAND_HEADROOM
+
 
 @dataclass(frozen=True)
 class AutostartResult:
@@ -87,11 +106,24 @@ def _configured_port() -> int:
 
 
 def _unit_installed() -> bool:
-    """True when a launchd/systemd/Windows unit for the gateway exists."""
-    try:
-        from flowly.cli.service_cmd import DEFAULT_SERVICE_LABEL, _service_paths
+    """True when a launchd/systemd/Windows definition for the gateway exists.
 
-        return any(p is not None and p.exists() for p in _service_paths(DEFAULT_SERVICE_LABEL))
+    Includes the Windows Startup-folder launcher: without admin rights the
+    installer falls back to that instead of a scheduled task, and treating it
+    as "nothing installed" would make every launch take the heavier reinstall
+    path and announce a background service the user already had.
+    """
+    try:
+        from flowly.cli.service_cmd import (
+            DEFAULT_SERVICE_LABEL,
+            _service_paths,
+            _windows_startup_launcher,
+        )
+
+        candidates = list(_service_paths(DEFAULT_SERVICE_LABEL))
+        if sys.platform == "win32":
+            candidates.append(_windows_startup_launcher(DEFAULT_SERVICE_LABEL))
+        return any(p is not None and p.exists() for p in candidates)
     except Exception:
         return False
 
@@ -144,7 +176,9 @@ def ensure_gateway_running(
     argv += ["service", "install", "--start"] if install_unit else ["service", "start"]
 
     try:
-        completed = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+        completed = subprocess.run(
+            argv, capture_output=True, text=True, timeout=_command_timeout()
+        )
     except Exception as exc:  # noqa: BLE001 — a failed start must not kill the CLI
         return AutostartResult(running=False, attempted=True, detail=str(exc))
 

--- a/flowly/profile.py
+++ b/flowly/profile.py
@@ -73,6 +73,18 @@ def get_flowly_home() -> Path:
     return _DEFAULT_HOME
 
 
+def default_home() -> Path:
+    """The canonical home (``~/.flowly``), regardless of what is active.
+
+    ``get_flowly_home()`` answers "where am I writing?"; this answers "which
+    home owns the shared, non-profile-scoped resources?" — chiefly the
+    background-service label, which is a single global name every home would
+    otherwise fight over. Callers that need to tell "this unit is mine" from
+    "this unit belongs to the default install" compare against this.
+    """
+    return _DEFAULT_HOME
+
+
 def is_default_home() -> bool:
     """True iff the active ``FLOWLY_HOME`` is the default (``~/.flowly``)."""
     return get_flowly_home() == _DEFAULT_HOME

--- a/flowly/tui/entry.py
+++ b/flowly/tui/entry.py
@@ -22,6 +22,8 @@ import time
 import typer
 from rich.console import Console
 
+from flowly.integrations.active_provider import provider_readiness
+from flowly.integrations.gateway_autostart import ensure_gateway_running
 from flowly.tui.state import (
     canonical_session_key,
     fresh_session_key,
@@ -37,6 +39,16 @@ def _gateway_reachable(host: str, port: int, timeout: float = 0.5) -> bool:
         with socket.create_connection((host, port), timeout=timeout):
             return True
     except OSError:
+        return False
+
+
+def _is_remote_host(host: str) -> bool:
+    """True when ``host`` names another machine, so there is nothing here to start."""
+    try:
+        from flowly.gateway.auth import is_loopback_host
+
+        return not is_loopback_host(host)
+    except Exception:
         return False
 
 
@@ -188,17 +200,7 @@ def run_tui(
         # but gateway not running" (→ start it). A fresh user hits the
         # former; pointing them at `flowly gateway` there would just bounce
         # them off the gateway's own no-provider error.
-        configured = False
-        try:
-            from flowly.config.loader import load_config
-            from flowly.integrations.active_provider import (
-                resolve_active_provider,
-            )
-            configured = resolve_active_provider(load_config()) is not None
-        except Exception:
-            configured = False
-
-        if not configured:
+        if not provider_readiness().ready:
             # Fresh install — run the unified onboarding (account or API key)
             # instead of a bare "not configured" message. TTY-guarded inside;
             # non-interactive contexts just get guidance and return.
@@ -206,17 +208,40 @@ def run_tui(
             run_onboarding()
             raise typer.Exit(code=0)
 
-        console.print(f"[red]Gateway not reachable on {host}:{port}.[/red]")
-        console.print("Start the gateway, then run [bold]flowly[/bold] again:")
-        console.print(
-            "  [bold]flowly service install --start[/bold]  "
-            "[dim](background)[/dim]"
-        )
-        console.print(
-            "  [bold]flowly gateway[/bold]                  "
-            "[dim](foreground, in another terminal)[/dim]"
-        )
-        raise typer.Exit(code=1)
+        # Provider ready, gateway down: this is ours to fix. Starting it is
+        # exactly what the old message asked the user to go and type.
+        result = ensure_gateway_running(host, port)
+        if result.running:
+            if result.installed_unit:
+                # A persistent service is a change to their machine, so it
+                # gets one line — and the way back out.
+                console.print(
+                    "[dim]Started Flowly in the background "
+                    "(stop it any time with [/dim][bold]flowly service uninstall[/bold][dim]).[/dim]"
+                )
+        else:
+            console.print(f"[red]Gateway not reachable on {host}:{port}.[/red]")
+            if result.detail:
+                console.print(f"  [dim]{result.detail}[/dim]")
+            if _is_remote_host(host):
+                # Nothing local to start — telling them to install a service
+                # here would point them at the wrong machine entirely.
+                console.print(
+                    f"That gateway runs on [bold]{host}[/bold]. Check it's up "
+                    f"there and that port {port} is reachable "
+                    "[dim](firewall, VPN, same Wi-Fi)[/dim]."
+                )
+            else:
+                console.print("Start the gateway, then run [bold]flowly[/bold] again:")
+                console.print(
+                    "  [bold]flowly service install --start[/bold]  "
+                    "[dim](background)[/dim]"
+                )
+                console.print(
+                    "  [bold]flowly gateway[/bold]                  "
+                    "[dim](foreground, in another terminal)[/dim]"
+                )
+            raise typer.Exit(code=1)
 
     # Every launch starts a fresh session by default. ``--resume`` opens a
     # terminal session picker (like ``flowly setup``'s menus) and launches

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -668,6 +668,11 @@ Write-Host ''
 if (-not $SkipBootstrap -and -not [System.Console]::IsInputRedirected) {
     try { & $flowly setup }
     catch { try { & $flowly bootstrap } catch {} }
+
+    # No "now start the gateway" step: the CLI starts it on demand.
+    Write-Host ''
+    Write-Host 'Get started (open a new terminal first so PATH is picked up):'
+    Write-Host '  flowly                             # start chatting'
 }
 else {
     if (-not $SkipBootstrap) {
@@ -676,6 +681,5 @@ else {
     }
     Write-Host 'Get started (open a new terminal first so PATH is picked up):'
     Write-Host '  1. flowly setup                    # choose an account or API key'
-    Write-Host '  2. flowly service install --start  # run the gateway in the background'
-    Write-Host '  3. flowly                          # start chatting'
+    Write-Host '  2. flowly                          # start chatting'
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -789,6 +789,36 @@ main() {
 # reports ok but the gateway never binds its port again. Rewrite the unit
 # against this install and restart it. This also means a re-run-to-update
 # actually bounces the running gateway onto the new code.
+#
+# It must only adopt a unit that is actually THIS install's to adopt. The
+# service label is a single global name, and FLOWLY_SRC / FLOWLY_VENV can point
+# anywhere — that is how CI and anyone testing a branch run this script. Blindly
+# rewriting the unit repoints the machine's real background service at a
+# throwaway venv, and breaks the gateway for good the moment that directory is
+# cleaned up. So: adopt the unit when it is ours or when it dangles (the case
+# this function exists for), and otherwise leave it exactly as we found it.
+unit_exec_path() {
+  local unit="$1"
+  "${FLOWLY_VENV}/bin/python" - "$unit" <<'EOF' 2>/dev/null || true
+import plistlib, shlex, sys
+from pathlib import Path
+
+unit = Path(sys.argv[1])
+try:
+    if unit.suffix == ".plist":
+        argv = plistlib.loads(unit.read_bytes()).get("ProgramArguments") or []
+        print(argv[0] if argv else "")
+    else:
+        for line in unit.read_text(encoding="utf-8").splitlines():
+            if line.startswith("ExecStart="):
+                tokens = shlex.split(line.split("=", 1)[1].strip())
+                print(tokens[0] if tokens else "")
+                break
+except Exception:
+    pass
+EOF
+}
+
 refresh_service() {
   local flowly_bin="$1"
   local unit=""
@@ -797,6 +827,14 @@ refresh_service() {
     Linux)  unit="${HOME}/.config/systemd/user/ai.flowly.gateway.service" ;;
   esac
   [[ -n "$unit" && -f "$unit" ]] || return 0
+
+  local current
+  current="$(unit_exec_path "$unit")"
+  if [[ -n "$current" && -x "$current" && "$current" != "${FLOWLY_VENV}/bin/flowly" ]]; then
+    log "Leaving the existing background service alone — it belongs to another install:"
+    log "  ${current}"
+    return 0
+  fi
 
   log "Refreshing the background service to point at this install..."
   if "$flowly_bin" service install --start >/dev/null 2>&1; then
@@ -826,8 +864,11 @@ print_next_steps() {
     printf '\n'
   fi
 
+  # One command, not two. `flowly service install --start` used to be listed
+  # here as a step the user had to perform before the product would work —
+  # the CLI now starts the gateway on demand, so the only thing left to type
+  # is the thing they actually came for.
   printf 'Get started:\n'
-  printf '  flowly service install --start   # run the gateway in the background\n'
   printf '  flowly                           # start chatting\n'
 }
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -11,7 +11,12 @@ from flowly.cli import doctor as doctor_module
 from flowly.cli.doctor import run_doctor
 from flowly.config.loader import convert_to_camel
 from flowly.config.schema import Config
-from flowly.diagnostics.checks import _service_command_and_home, check_profile_isolation
+from flowly.diagnostics import checks as checks_module
+from flowly.diagnostics.checks import (
+    _service_command_and_home,
+    check_profile_isolation,
+    check_service_definition,
+)
 from flowly.diagnostics.config import find_unknown_keys, read_config_snapshot
 from flowly.diagnostics.models import DoctorCheck, DoctorContext, Status
 from flowly.diagnostics.repairs import (
@@ -775,6 +780,100 @@ def test_windows_service_parser_reads_production_xml_and_vbs(tmp_path: Path) -> 
     assert parsed_home == str(profile)
     assert "gateway" in argv
     assert "19999" in argv
+
+
+def _write_launchd_plist(path: Path, *, executable: Path, home: Path) -> None:
+    import plistlib
+
+    path.write_bytes(
+        plistlib.dumps(
+            {
+                "Label": "ai.flowly.gateway",
+                "ProgramArguments": [str(executable), "gateway", "--port", "18790"],
+                "EnvironmentVariables": {"FLOWLY_HOME": str(home)},
+            }
+        )
+    )
+
+
+def test_foreign_home_service_is_not_reported_against_this_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A unit owned by another Flowly home must not fail this profile's doctor.
+
+    The launchd/systemd label is global, so a profile (or a second product
+    built on this codebase) sees the *default* home's unit at the well-known
+    path. Validating that foreign unit's executable produced a hard ERROR —
+    "Service executable does not exist" — about an install this profile has
+    nothing to do with, which is also why the read-only doctor test failed on
+    any developer machine with Flowly installed.
+    """
+    other_home = tmp_path / "other-home"
+    other_home.mkdir()
+    plist = tmp_path / "ai.flowly.gateway.plist"
+    _write_launchd_plist(
+        plist, executable=tmp_path / "deleted-worktree" / "flowly", home=other_home
+    )
+
+    this_home = tmp_path / "this-profile"
+    this_home.mkdir()
+    monkeypatch.setattr(checks_module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(checks_module, "_service_path", lambda: plist)
+    monkeypatch.setattr(checks_module, "default_home", lambda: tmp_path / "default")
+
+    ctx = DoctorContext(data_dir=this_home)
+    check_service_definition(ctx)
+
+    (result,) = ctx.results
+    assert result.status is Status.WARN
+    assert "executable" not in result.message.lower()
+    assert str(other_home) in result.detail
+
+
+def test_default_home_still_errors_when_its_service_was_taken_over(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On the default home a foreign unit means someone clobbered your service."""
+    default_home = tmp_path / "default"
+    default_home.mkdir()
+    other_home = tmp_path / "other-home"
+    other_home.mkdir()
+    executable = tmp_path / "flowly"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    plist = tmp_path / "ai.flowly.gateway.plist"
+    _write_launchd_plist(plist, executable=executable, home=other_home)
+
+    monkeypatch.setattr(checks_module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(checks_module, "_service_path", lambda: plist)
+    monkeypatch.setattr(checks_module, "default_home", lambda: default_home)
+
+    ctx = DoctorContext(data_dir=default_home)
+    check_service_definition(ctx)
+
+    (result,) = ctx.results
+    assert result.status is Status.ERROR
+    assert str(other_home) in result.detail
+
+
+def test_matching_home_service_is_still_fully_validated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reordering the home comparison must not stop us validating our own unit."""
+    home = tmp_path / "home"
+    home.mkdir()
+    plist = tmp_path / "ai.flowly.gateway.plist"
+    _write_launchd_plist(plist, executable=tmp_path / "gone" / "flowly", home=home)
+
+    monkeypatch.setattr(checks_module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(checks_module, "_service_path", lambda: plist)
+    monkeypatch.setattr(checks_module, "default_home", lambda: home)
+
+    ctx = DoctorContext(data_dir=home)
+    check_service_definition(ctx)
+
+    (result,) = ctx.results
+    assert result.status is Status.ERROR
+    assert "executable does not exist" in result.message
 
 
 def test_windows_service_parser_supports_startup_fallback(tmp_path: Path) -> None:

--- a/tests/test_gateway_autostart.py
+++ b/tests/test_gateway_autostart.py
@@ -1,0 +1,335 @@
+"""Bare ``flowly`` starts its own gateway instead of assigning homework.
+
+A configured user who typed ``flowly`` used to get three lines telling them
+to run ``flowly service install --start`` and try again. The product knows
+how to do that, so it does it.
+
+The guards matter as much as the behaviour: this must never fire inside
+Flowly Desktop (which spawns the binary as a non-TTY subprocess and owns the
+gateway lifecycle itself), never install a unit for a port the user only
+asked about on the command line, and never try to "start" a gateway that
+lives on another machine.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from flowly.integrations import gateway_autostart as autostart
+
+
+@pytest.fixture
+def never_runs(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    """Record subprocess launches; fail loudly if one escapes a guard."""
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **_kwargs):
+        calls.append(list(argv))
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(autostart.subprocess, "run", fake_run)
+    monkeypatch.setattr(autostart, "_flowly_argv", lambda: ["flowly"])
+    return calls
+
+
+@pytest.fixture
+def interactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(autostart.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.delenv("FLOWLY_NO_GATEWAY_AUTOSTART", raising=False)
+
+
+def _reachable(*ports: int):
+    return lambda host, port, timeout=0.5: port in ports
+
+
+def test_running_gateway_is_left_alone(
+    monkeypatch: pytest.MonkeyPatch, never_runs, interactive
+) -> None:
+    monkeypatch.setattr(autostart, "_port_open", _reachable(18790))
+
+    result = autostart.ensure_gateway_running("127.0.0.1", 18790)
+
+    assert result.running is True
+    assert result.attempted is False
+    assert never_runs == []
+
+
+def test_installs_and_starts_when_no_unit_exists(
+    monkeypatch: pytest.MonkeyPatch, never_runs, interactive
+) -> None:
+    monkeypatch.setattr(autostart, "_unit_installed", lambda: False)
+    monkeypatch.setattr(autostart, "_configured_port", lambda: 18790)
+    ports: set[int] = set()
+    monkeypatch.setattr(autostart, "_port_open", lambda h, p, timeout=0.5: p in ports)
+
+    def fake_run(argv, **_kwargs):
+        never_runs.append(list(argv))
+        ports.add(18790)  # the service came up
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(autostart.subprocess, "run", fake_run)
+
+    result = autostart.ensure_gateway_running("127.0.0.1", 18790)
+
+    assert result.running is True
+    assert result.installed_unit is True
+    assert never_runs == [["flowly", "service", "install", "--start"]]
+
+
+def test_existing_unit_is_only_started_not_reinstalled(
+    monkeypatch: pytest.MonkeyPatch, never_runs, interactive
+) -> None:
+    monkeypatch.setattr(autostart, "_unit_installed", lambda: True)
+    monkeypatch.setattr(autostart, "_configured_port", lambda: 18790)
+    ports: set[int] = set()
+    monkeypatch.setattr(autostart, "_port_open", lambda h, p, timeout=0.5: p in ports)
+
+    def fake_run(argv, **_kwargs):
+        never_runs.append(list(argv))
+        ports.add(18790)
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(autostart.subprocess, "run", fake_run)
+
+    result = autostart.ensure_gateway_running("127.0.0.1", 18790)
+
+    assert result.running is True
+    assert result.installed_unit is False
+    assert never_runs == [["flowly", "service", "start"]]
+
+
+def test_non_tty_never_autostarts(
+    monkeypatch: pytest.MonkeyPatch, never_runs
+) -> None:
+    """Flowly Desktop spawns the binary as a non-TTY subprocess and manages
+    the gateway itself — autostart must be invisible there."""
+    monkeypatch.delenv("FLOWLY_NO_GATEWAY_AUTOSTART", raising=False)
+    monkeypatch.setattr(autostart.sys.stdin, "isatty", lambda: False, raising=False)
+    monkeypatch.setattr(autostart, "_port_open", _reachable())
+
+    result = autostart.ensure_gateway_running("127.0.0.1", 18790)
+
+    assert result.running is False
+    assert result.attempted is False
+    assert never_runs == []
+
+
+def test_opt_out_env_var_is_honoured(
+    monkeypatch: pytest.MonkeyPatch, never_runs, interactive
+) -> None:
+    monkeypatch.setenv("FLOWLY_NO_GATEWAY_AUTOSTART", "1")
+    monkeypatch.setattr(autostart, "_port_open", _reachable())
+
+    result = autostart.ensure_gateway_running("127.0.0.1", 18790)
+
+    assert result.attempted is False
+    assert never_runs == []
+
+
+def test_remote_gateway_is_never_started_locally(
+    monkeypatch: pytest.MonkeyPatch, never_runs, interactive
+) -> None:
+    """``flowly --host 192.168.1.20`` targets another machine's gateway."""
+    monkeypatch.setattr(autostart, "_port_open", _reachable())
+
+    result = autostart.ensure_gateway_running("192.168.1.20", 18790)
+
+    assert result.attempted is False
+    assert never_runs == []
+
+
+def test_a_one_off_port_never_installs_a_unit(
+    monkeypatch: pytest.MonkeyPatch, never_runs, interactive
+) -> None:
+    """``flowly --port 9999`` must not bake 9999 into the machine's service."""
+    monkeypatch.setattr(autostart, "_unit_installed", lambda: False)
+    monkeypatch.setattr(autostart, "_configured_port", lambda: 18790)
+    monkeypatch.setattr(autostart, "_port_open", _reachable())
+
+    result = autostart.ensure_gateway_running("127.0.0.1", 9999)
+
+    assert result.attempted is False
+    assert result.installed_unit is False
+    assert never_runs == []
+
+
+def test_failure_reports_why_without_raising(
+    monkeypatch: pytest.MonkeyPatch, interactive
+) -> None:
+    monkeypatch.setattr(autostart, "_unit_installed", lambda: True)
+    monkeypatch.setattr(autostart, "_configured_port", lambda: 18790)
+    monkeypatch.setattr(autostart, "_port_open", _reachable())
+    monkeypatch.setattr(autostart, "_flowly_argv", lambda: ["flowly"])
+
+    def failing_run(argv, **_kwargs):
+        class _Result:
+            returncode = 1
+            stdout = ""
+            stderr = "launchctl: Operation not permitted"
+
+        return _Result()
+
+    monkeypatch.setattr(autostart.subprocess, "run", failing_run)
+
+    result = autostart.ensure_gateway_running("127.0.0.1", 18790, timeout=0.1)
+
+    assert result.running is False
+    assert result.attempted is True
+    assert "Operation not permitted" in result.detail
+
+
+class _FakeTUI:
+    launched: list[str] = []
+
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+
+    def run(self):
+        _FakeTUI.launched.append(self._kwargs.get("session_key", ""))
+
+
+@pytest.fixture
+def tui_without_gateway(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """``flowly`` on a configured install whose gateway is down."""
+    import flowly.tui.app as tui_app
+    import flowly.tui.entry as entry
+    from flowly.integrations.active_provider import ProviderReadiness
+
+    home = tmp_path / "flowly-home"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("FLOWLY_HOME", str(home))
+    monkeypatch.setattr(entry, "_gateway_reachable", lambda *a, **k: False)
+    monkeypatch.setattr(
+        entry,
+        "provider_readiness",
+        lambda: ProviderReadiness(ready=True, provider=None, has_account=False),
+    )
+    monkeypatch.setattr(tui_app, "FlowlyTUI", _FakeTUI)
+    _FakeTUI.launched = []
+    return entry
+
+
+def test_bare_flowly_starts_the_gateway_and_opens_the_ui(
+    tui_without_gateway, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    entry = tui_without_gateway
+    monkeypatch.setattr(
+        entry,
+        "ensure_gateway_running",
+        lambda host, port: autostart.AutostartResult(
+            running=True, attempted=True, installed_unit=True
+        ),
+    )
+
+    entry.run_tui(host="127.0.0.1", port=18790)
+
+    assert len(_FakeTUI.launched) == 1
+    out = capsys.readouterr().out
+    # Installing a background service changes their machine — say so once.
+    assert "background" in out.lower()
+
+
+def test_silent_when_an_existing_service_just_needed_starting(
+    tui_without_gateway, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    entry = tui_without_gateway
+    monkeypatch.setattr(
+        entry,
+        "ensure_gateway_running",
+        lambda host, port: autostart.AutostartResult(
+            running=True, attempted=True, installed_unit=False
+        ),
+    )
+
+    entry.run_tui(host="127.0.0.1", port=18790)
+
+    assert len(_FakeTUI.launched) == 1
+    assert capsys.readouterr().out.strip() == ""
+
+
+def test_manual_instructions_survive_when_autostart_fails(
+    tui_without_gateway, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    import typer
+
+    entry = tui_without_gateway
+    monkeypatch.setattr(
+        entry,
+        "ensure_gateway_running",
+        lambda host, port: autostart.AutostartResult(
+            running=False, attempted=True, detail="launchctl said no"
+        ),
+    )
+
+    with pytest.raises(typer.Exit) as exc:
+        entry.run_tui(host="127.0.0.1", port=18790)
+
+    assert exc.value.exit_code == 1
+    out = capsys.readouterr().out
+    assert "launchctl said no" in out
+    assert "flowly gateway" in out
+    assert _FakeTUI.launched == []
+
+
+def test_remote_host_gets_remote_advice_not_a_local_service_command(
+    tui_without_gateway, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """``flowly --host 192.168.1.20`` dials another machine's gateway.
+
+    "Run flowly service install --start" would install a service on THIS
+    machine, which is not the one that isn't answering.
+    """
+    import typer
+
+    entry = tui_without_gateway
+    monkeypatch.setattr(
+        entry,
+        "ensure_gateway_running",
+        lambda host, port: autostart.AutostartResult(
+            running=False, detail="192.168.1.20 is not this machine"
+        ),
+    )
+
+    with pytest.raises(typer.Exit):
+        entry.run_tui(host="192.168.1.20", port=18790)
+
+    out = capsys.readouterr().out
+    assert "service install" not in out
+    assert "192.168.1.20" in out
+
+
+def test_a_broken_launcher_does_not_crash_the_cli(
+    monkeypatch: pytest.MonkeyPatch, interactive
+) -> None:
+    monkeypatch.setattr(autostart, "_unit_installed", lambda: True)
+    monkeypatch.setattr(autostart, "_configured_port", lambda: 18790)
+    monkeypatch.setattr(autostart, "_port_open", _reachable())
+    monkeypatch.setattr(autostart, "_flowly_argv", lambda: ["flowly"])
+
+    def exploding_run(argv, **_kwargs):
+        raise OSError("no such file")
+
+    monkeypatch.setattr(autostart.subprocess, "run", exploding_run)
+
+    result = autostart.ensure_gateway_running("127.0.0.1", 18790, timeout=0.1)
+
+    assert result.running is False
+    assert "no such file" in result.detail

--- a/tests/test_gateway_autostart.py
+++ b/tests/test_gateway_autostart.py
@@ -289,6 +289,48 @@ def test_manual_instructions_survive_when_autostart_fails(
     assert _FakeTUI.launched == []
 
 
+def test_we_never_kill_a_service_start_that_is_still_within_its_own_budget() -> None:
+    """Our timeout must outlast the child's, or we abort legitimate starts.
+
+    ``flowly service install --start`` waits for the gateway's health endpoint
+    before returning (up to SERVICE_START_TOTAL_BUDGET). Interpreter startup
+    and the launchctl/systemctl round trip sit on top of that. A timeout equal
+    to the child's budget would kill it mid-install and report a failure that
+    did not happen — and would do it most often on the slowest machines.
+    """
+    from flowly.cli.service_cmd import SERVICE_START_TOTAL_BUDGET
+
+    assert autostart._command_timeout() > SERVICE_START_TOTAL_BUDGET + 10
+
+
+def test_the_port_wait_is_not_the_command_timeout(
+    monkeypatch: pytest.MonkeyPatch, interactive
+) -> None:
+    """A short ``timeout`` bounds how long we wait for the socket, not how long
+    the service manager is allowed to take."""
+    seen: dict[str, float] = {}
+    monkeypatch.setattr(autostart, "_unit_installed", lambda: True)
+    monkeypatch.setattr(autostart, "_configured_port", lambda: 18790)
+    monkeypatch.setattr(autostart, "_port_open", _reachable())
+    monkeypatch.setattr(autostart, "_flowly_argv", lambda: ["flowly"])
+
+    def fake_run(argv, **kwargs):
+        seen["timeout"] = kwargs.get("timeout", 0.0)
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(autostart.subprocess, "run", fake_run)
+
+    autostart.ensure_gateway_running("127.0.0.1", 18790, timeout=0.1)
+
+    assert seen["timeout"] > 30
+
+
 def test_remote_host_gets_remote_advice_not_a_local_service_command(
     tui_without_gateway, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:

--- a/tests/test_installer_next_steps.py
+++ b/tests/test_installer_next_steps.py
@@ -1,0 +1,42 @@
+"""What the installer leaves on screen is the product's first instruction.
+
+Both installers used to close with a numbered list whose middle step was
+``flowly service install --start`` — a command the user had to run before
+anything worked. The CLI starts the gateway on demand now, so that step is
+gone; these tests keep it gone, because the failure mode is silent (an
+installer that still prescribes it simply looks like a longer product).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _get_started_block(text: str) -> str:
+    """Everything from the 'Get started' heading to the end of its block."""
+    marker = text.index("Get started")
+    return text[marker : marker + 400]
+
+
+@pytest.mark.parametrize("script", ["install.sh", "install.ps1"])
+def test_get_started_does_not_prescribe_starting_the_gateway(script: str) -> None:
+    block = _get_started_block((SCRIPTS / script).read_text(encoding="utf-8"))
+
+    assert "flowly" in block
+    assert "service install" not in block, (
+        f"{script} still tells the user to start the gateway by hand"
+    )
+
+
+def test_unix_installer_offers_exactly_one_command() -> None:
+    block = _get_started_block((SCRIPTS / "install.sh").read_text(encoding="utf-8"))
+    commands = [
+        line for line in block.splitlines() if "flowly" in line and "printf" in line
+    ]
+
+    assert len(commands) == 1
+    assert "start chatting" in commands[0]

--- a/tests/test_login_provider_verdict.py
+++ b/tests/test_login_provider_verdict.py
@@ -1,0 +1,79 @@
+"""``flowly login`` must not claim a provider it didn't get.
+
+``ensure_account_key`` mints the ``flw_…`` key that bills LLM usage to the
+account. It is best-effort by design and returns False on any failure — a
+502 from the backend, a dropped connection, an expired token. Nothing looked
+at that return value, so a sign-in whose mint failed still printed
+
+    ✓ Signed in as you@example.com — Flowly provider ready, billed to your
+      account (no relay).
+    Ready. Run flowly to start chatting.
+
+and the user then found the gateway refusing to start. These tests hold the
+final message to what actually happened.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import flowly.cli.login_cmd as login_cmd
+from flowly.integrations.active_provider import ProviderReadiness
+
+
+def _readiness(monkeypatch: pytest.MonkeyPatch, ready: bool) -> None:
+    monkeypatch.setattr(
+        login_cmd,
+        "provider_readiness",
+        lambda: ProviderReadiness(ready=ready, provider=None, has_account=True),
+    )
+
+
+def test_a_working_sign_in_says_ready(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    _readiness(monkeypatch, ready=True)
+
+    assert login_cmd._print_provider_verdict() is True
+
+    out = capsys.readouterr().out
+    assert "Ready" in out
+    assert "flowly" in out
+
+
+def test_a_failed_mint_is_reported_instead_of_claimed(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    _readiness(monkeypatch, ready=False)
+
+    assert login_cmd._print_provider_verdict() is False
+
+    out = capsys.readouterr().out
+    assert "Ready. Run" not in out
+    # Must name the actual repair, not send them back through setup.
+    assert "flowly login" in out
+    lowered = out.lower()
+    assert "signed in" in lowered
+    assert "account key" in lowered
+
+
+def test_repair_reissues_the_account_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``flowly login --repair`` is where a user lands after a failed mint.
+
+    It re-registered the server and rewrote relay config but never retried
+    the mint, so the one thing that was actually broken stayed broken.
+    """
+    minted: list[str] = []
+    monkeypatch.setattr(
+        login_cmd,
+        "_mint_and_save_account_key",
+        lambda account: minted.append(getattr(account, "user_id", "?")) or True,
+    )
+
+    class _Account:
+        user_id = "uid-1"
+        email = "someone@example.com"
+
+    login_cmd._repair_account_credentials(_Account())
+
+    assert minted == ["uid-1"]

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -1,0 +1,158 @@
+"""One definition of "can Flowly serve a request right now?".
+
+Two call sites used to answer this differently and the disagreement was a
+trap a first-run user could fall into and not get out of:
+
+* ``onboard_cmd._already_configured()`` counted a signed-in Flowly account
+  as configured, even when no usable credential ever landed in the config
+  (``ensure_account_key`` is best-effort and returns False silently).
+* ``service_cmd._provider_configured()`` asked ``resolve_active_provider``,
+  which in that state answers "nothing usable".
+
+So onboarding said "you're set", ``service install --start`` refused to
+start the gateway, and bare ``flowly`` — seeing no provider — reopened
+onboarding. Round and round.
+
+These tests pin the two answers together and keep the in-between state
+("signed in, nothing usable") nameable so the UI can say what happened
+instead of looping.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from flowly.config.loader import convert_to_camel
+from flowly.config.schema import Config
+from flowly.integrations.active_provider import provider_readiness
+
+
+def _write_config(home: Path, config: Config) -> None:
+    raw = convert_to_camel(config.model_dump())
+    path = home / "config.json"
+    path.write_text(json.dumps(raw, indent=2), encoding="utf-8")
+    path.chmod(0o600)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An isolated FLOWLY_HOME with no account and no credentials.
+
+    The subscription providers (ChatGPT/Codex, xAI Grok, GLM) deliberately
+    reuse credentials that live OUTSIDE ``FLOWLY_HOME`` — the user's Codex
+    or OpenCode login. That is a feature, but it means a developer machine
+    resolves a provider from an otherwise empty config, so these tests
+    silence them to keep the cascade under test hermetic.
+    """
+    flowly_home = tmp_path / "flowly-home"
+    flowly_home.mkdir(mode=0o700)
+    monkeypatch.setenv("FLOWLY_HOME", str(flowly_home))
+    monkeypatch.setattr("flowly.account.auth.load_account_sync", lambda: None)
+    for module in ("openai_codex", "xai_oauth", "zai_coding"):
+        monkeypatch.setattr(
+            f"flowly.auth.{module}.resolve_runtime_credentials",
+            lambda *_args, **_kwargs: None,
+        )
+    return flowly_home
+
+
+def _sign_in(monkeypatch: pytest.MonkeyPatch, **fields) -> None:
+    """Pretend an account is stored, with whatever credentials are given."""
+    from flowly.account.auth import Account
+
+    account = Account(
+        user_id="uid-1",
+        email="someone@example.com",
+        id_token="id-token",
+        refresh_token="refresh-token",
+        expires_at=4_102_444_800,
+        machine_id="machine-1",
+        machine_name="test-machine",
+        **fields,
+    )
+    monkeypatch.setattr("flowly.account.auth.load_account_sync", lambda: account)
+
+
+def test_byok_key_is_ready(home: Path) -> None:
+    config = Config()
+    config.providers.active = "openrouter"
+    config.providers.openrouter.api_key = "sk-or-v1-test"
+    _write_config(home, config)
+
+    state = provider_readiness()
+
+    assert state.ready is True
+    assert state.has_account is False
+    assert state.provider is not None
+    assert state.provider.key == "openrouter"
+
+
+def test_signed_in_but_mint_failed_is_not_ready(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exact state a failed ``ensure_account_key`` leaves behind.
+
+    ``providers.flowly.enabled`` defaults True, so the config *looks* like
+    the hosted provider is on — but there is no account key, no relay pair
+    and no server registration, so nothing can actually be billed.
+    """
+    _write_config(home, Config())
+    _sign_in(monkeypatch, server_id="", gateway_auth_token="")
+
+    state = provider_readiness()
+
+    assert state.ready is False
+    assert state.has_account is True
+    assert state.provider is None
+
+
+def test_signed_in_with_relay_registration_is_ready(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_config(home, Config())
+    _sign_in(monkeypatch, server_id="srv-1", gateway_auth_token="tok-1")
+
+    state = provider_readiness()
+
+    assert state.ready is True
+    assert state.provider is not None
+    assert state.provider.key == "flowly"
+
+
+def test_nothing_configured_at_all(home: Path) -> None:
+    _write_config(home, Config())
+
+    state = provider_readiness()
+
+    assert state.ready is False
+    assert state.has_account is False
+
+
+def test_onboarding_and_service_never_disagree(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The regression guard for the loop this whole module exists to prevent.
+
+    Whatever the state, the screen that decides "setup is done" and the
+    command that decides "the gateway may start" must agree — otherwise the
+    user is told they are ready and then refused.
+    """
+    from flowly.cli.onboard_cmd import _already_configured
+    from flowly.cli.service_cmd import _provider_configured
+
+    # 1. Nothing at all.
+    _write_config(home, Config())
+    assert _already_configured() == _provider_configured() is False
+
+    # 2. Signed in, but the account key never minted — the trap.
+    _sign_in(monkeypatch, server_id="", gateway_auth_token="")
+    assert _already_configured() == _provider_configured() is False
+
+    # 3. Signed in with a working account key.
+    config = Config()
+    config.providers.flowly.account_key = "flw_test"
+    _write_config(home, config)
+    assert _already_configured() == _provider_configured() is True


### PR DESCRIPTION
Fixes the P0s from a UX report by a first-time installer.

## What was broken

**The gateway was the user's problem.** A configured install whose gateway wasn't running printed three lines telling them to run `flowly service install --start` and try again. The installer closed with the same instruction. "Installed" and "usable" were different states, and nothing said so.

**Worse, there was a loop with no exit.** `ensure_account_key()` mints the key that bills LLM usage. It is best-effort, returns `False` on any failure, and nobody looked at the result — so login still printed *"Flowly provider ready, billed to your account"*. Onboarding agreed (it counted "signed in" as configured). The service preflight disagreed (it asks `resolve_active_provider`) and refused to start. Bare `flowly`, finding no provider, reopened onboarding. Round again — with all three parts saying different things and none naming the real cause.

## What changed

- **`flowly` starts the gateway itself.** New `ensure_gateway_running()`: start an installed unit, or install and start one, then wait for the port. Guards are the point — never for a non-loopback `--host`, never bakes a one-off `--port` into a unit, never outside an interactive terminal (which is exactly how Flowly Desktop spawns this binary, and Desktop owns its own gateway lifecycle), and `FLOWLY_NO_GATEWAY_AUTOSTART=1` opts out. Failure is a report, not an exception: the old instructions still appear, now with the reason.
- **One definition of "provider ready"** (`provider_readiness()`), shared by onboarding, the service preflight and smart entry, with `has_account` kept separate so "signed in, nothing usable" stays nameable.
- **Login says what happened**, and `--repair` re-issues the account key it used to skip.
- **Doctor** no longer reports another home's service unit as this profile's error — also why the read-only doctor test failed on any machine with Flowly installed.
- **`install.sh` won't hijack someone else's service.** `FLOWLY_SRC`/`FLOWLY_VENV` can point anywhere (that is how CI and branch testing run it); it used to repoint the machine's real unit at a throwaway venv, which breaks the gateway once that directory is cleaned up. Found the hard way.
- **Docs match the product again** — six pages still sold the service as the missing step.

## Verification

- 3194 tests green (baseline had one failing on any dev machine — fixed here). 32 new tests.
- `ruff`: byte-identical findings before/after on every touched file.
- Installer CI dispatched on this branch: ubuntu ✅ macOS ✅ Windows ✅, each running the installer twice.
- Isolated end-to-end run on macOS: fresh install → onboarding; non-TTY → no service ever spawned and the reason printed; opt-out honoured; a running gateway left alone; `flowly bootstrap` (Desktop's path) intact; doctor clean.

## Known gap

The real launchd/systemd/Task-Scheduler install-and-start leg has not run end-to-end anywhere — CI installers use `--skip-bootstrap`, and exercising it locally would clobber the maintainer's own unit. The decision logic around it is covered; the failure mode is bounded (you get today's message plus a reason). Worth a follow-up CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)